### PR TITLE
Minor fix to add required mongo_write_concern parameter

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,2 @@
 Chris Nelson (https://github.com/crnelson)
+Sokratis Galiatsis (https://github.com/sokratisg)

--- a/src/cdr_mongodb.c
+++ b/src/cdr_mongodb.c
@@ -176,7 +176,7 @@ static int mongodb_log(struct ast_cdr *cdr)
 	bson_finish(&b);
 
 	ast_debug(1, "mongodb: Inserting a CDR record.\n");
-	mongo_insert( &conn , ast_str_buffer(dbnamespace) , &b );
+	mongo_insert( &conn , ast_str_buffer(dbnamespace) , &b, NULL );
 	bson_destroy(&b);
 	mongo_destroy( &conn );
 


### PR DESCRIPTION
In order for cdr_mongo.c to compile successfully with the latest stable mongo-c-driver, the mongo_write_concern parameter needs to be added in mongo_insert function.
